### PR TITLE
Fix permission issue for linux users

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,11 +9,10 @@ RUN apt install -y git curl zsh build-essential vim bash
 # Clean up after install to reduce image size
 RUN apt clean && rm -rf /var/lib/apt/lists/*
 
-# For security reason, it's best to create a user to avoid using root by default
-RUN useradd -m -s /bin/zsh appuser
-USER appuser
+# For security reason, it's best to use non-root user, and the ubuntu image come wiith default ubuntu by default
+USER ubuntu
 
-ENV HOME=/home/appuser
+ENV HOME=/home/ubuntu
 ENV PATH=${PATH}:${HOME}/.local/bin
 
 # Install nvm, nodejs and yarn

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,4 +60,4 @@ RUN ARCH=$(uname -m) && \
         exit 1; \
     fi
 
-WORKDIR /app
+WORKDIR /workspace


### PR DESCRIPTION
## Summary

This PR updates the `Dockerfile` to:
1. Use the default `ubuntu` user provided by the base `ubuntu:24.04` image instead of creating a new user (`appuser`).
2. Align the working directory (`WORKDIR`) with typical VS Code devcontainer behavior, setting it to `/workspace`.

## Additional Notes

- This update does not change the behavior for macOS or Windows users.
- The issue primarily affects Linux users because the User ID (UID) and Group ID (GID) of the local user must match those of the container user for proper file ownership and permissions.
- The default `ubuntu` user in the base image is assigned the UID and GID `1000:1000`, which is the same as most default Linux users. Creating a new user (`appuser`) assigns it `1001:1001`, breaking this ID synchronization.
- Since only the IDs matter, switching back to the default `ubuntu` user resolves this issue without impacting functionality.

Source
https://code.visualstudio.com/remote/advancedcontainers/add-nonroot-user
https://stackoverflow.com/questions/51066146/what-is-the-point-of-workdir-on-dockerfile
https://askubuntu.com/questions/1513927/ubuntu-24-04-docker-images-now-includes-user-ubuntu-with-uid-gid-1000